### PR TITLE
Changes bat files

### DIFF
--- a/Set-IP/README.md
+++ b/Set-IP/README.md
@@ -46,7 +46,7 @@ When running this script you will be prompted to insert your Ethernet Adapter in
 Most of the Ethernet settings has DHCP enabled, which allows the computer to use a dynamic IP provided by the router. 
 If that's your case, you can simply run this file to change back from static mode.
 
-If not, you can run the following code on CMD using the previous saved settings of your Ethernet interface.
+If not, you can run the following code on CMD using the previous saved settings of your Ethernet interface. Your old configuration is an *.txt file on your Desktop.
   ```batch
     netsh interface ip set address Ethernet static saved_ip_address saved_subnetmask saved_default_gateway
   ```

--- a/Set-IP/README.md
+++ b/Set-IP/README.md
@@ -36,9 +36,11 @@ All provided .bat scripts were tested on Windows 8.1 and requires system elevati
 When double clicking the bat file, you will be prompted to provide administrator privileges.
 
 ##### setStaticIP.bat
-A static IP for the host system (in this case Windows) along with embedded device is necessary for creating a local network that can communicate through SSH.
+A static IP for the host system (in this case Windows) along with a static IP for the embedded device is necessary for creating a local network that can communicate through SSH.
 
 This bat file, sets a static IP for the host and saves a copy of your previous Ethernet interface settings in a text file located on your Desktop.
+
+When running this script you will be prompted to insert your Ethernet Adapter interface's name; you can check that info in the output of ipconfig command, that is provided in the code.
 
 ##### setDHCP.bat
 Most of the Ethernet settings has DHCP enabled, which allows the computer to use a dynamic IP provided by the router. 

--- a/Set-IP/setDHCP.bat
+++ b/Set-IP/setDHCP.bat
@@ -29,10 +29,39 @@ if '%errorlevel%' NEQ '0' (
     CD /D "%~dp0"
 :-------------------------------------- 
 ECHO CHANGE ETHERNET INTERFACE FROM STATIC TO DHCP 
-netsh interface ip set address Ethernet dhcp
-ECHO Success!
-echo.
-ECHO Current configuration...
-echo.
-netsh interface ip show address Ethernet
-PAUSE 
+goto inputAdapterName
+
+:inputAdapterName
+	echo.
+	echo A list of your current network settings will be shown below. 
+	echo.
+	echo Search for your ethernet adapter's name 
+	echo.
+	echo E.g. 'Adapter Ethernet Ethernet' or 'Adapter Ethernet Local Area Connection'
+	echo.
+	pause
+	ipconfig
+	echo.
+	SET /P netName=From the list above...Please input your Ethernet Adapter name: 
+	GOTO checkAdapterName
+
+:checkAdapterName
+	echo.
+	netsh interface ip show address %netName% &&  GOTO confirmAdapter 2>nul GOTO inputAdapterName
+
+:confirmAdapter
+	echo. 
+	SET /P confirm=Is the above adaptor correct[y/n]?
+	IF /I {%confirm%}=={y} (
+		GOTO success
+	)ELSE (
+		goto inputAdapterName
+	)
+
+:success	
+	netsh interface ip set address %netName% dhcp && ECHO Success!
+	echo.
+	ECHO Current configuration...
+	echo.
+	netsh interface ip show address %netName%
+	PAUSE 

--- a/Set-IP/setDHCP.bat
+++ b/Set-IP/setDHCP.bat
@@ -47,7 +47,7 @@ goto inputAdapterName
 
 :checkAdapterName
 	echo.
-	netsh interface ip show address %netName% &&  GOTO confirmAdapter 2>nul GOTO inputAdapterName
+	netsh interface ip show address "%netName%" &&  GOTO confirmAdapter 2>nul GOTO inputAdapterName
 
 :confirmAdapter
 	echo. 
@@ -59,9 +59,9 @@ goto inputAdapterName
 	)
 
 :success	
-	netsh interface ip set address %netName% dhcp && ECHO Success!
+	netsh interface ip set address "%netName%" dhcp && ECHO Success!
 	echo.
 	ECHO Current configuration...
 	echo.
-	netsh interface ip show address %netName%
+	netsh interface ip show address "%netName%"
 	PAUSE 

--- a/Set-IP/setStaticIP.bat
+++ b/Set-IP/setStaticIP.bat
@@ -33,12 +33,37 @@ set filepath=%HOMEPATH%\Desktop\oldConfigEthernet.txt
 set ip=192.168.99.20
 set nm=255.255.255.0
 set gw=192.168.99.1
-GOTO printVar
+GOTO inputAdapterName
 
-:confirmAction
-	SET /P question=Do you want to use the above configuration[y/n]?
-	echo You chose: %question% 
+:inputAdapterName
+	echo.
+	echo A list of your current network settings will be shown below. 
+	echo.
+	echo Search for your ethernet adapter's name 
+	echo.
+	echo E.g. 'Adapter Ethernet Ethernet' or 'Adapter Ethernet Local Area Connection'
+	echo.
 	pause
+	ipconfig
+	echo.
+	SET /P netName=From the list above...Please input your Ethernet Adapter name: 
+	GOTO checkAdapterName
+
+:checkAdapterName
+	echo.
+	netsh interface ip show address %netName% &&  GOTO confirmAdapter 2>nul GOTO inputAdapterName
+
+:confirmAdapter
+	echo. 
+	SET /P confirm=Is the above adaptor correct[y/n]?
+	IF /I {%confirm%}=={y} (
+		GOTO printVar
+	)ELSE (
+		goto inputAdapterName
+	) 
+	
+	:confirmAction
+	SET /P question=Do you want to use the above configuration[y/n]?
 	IF /I {%question%}=={y} GOTO changeStatic
 	IF /I {%question%}=={n} (
 		GOTO setStatic
@@ -69,8 +94,8 @@ GOTO printVar
 
 :changeStatic
 	echo.
-	netsh interface ip show address Ethernet > %filepath%
-	netsh interface ip set address Ethernet static %ip% %nm% %gw% 
+	netsh interface ip show address %netName% > %filepath%
+	netsh interface ip set address %netName% static %ip% %nm% %gw% 
 	ECHO Success...Saved old configuration files on %filepath%
 
 PAUSE 

--- a/Set-IP/setStaticIP.bat
+++ b/Set-IP/setStaticIP.bat
@@ -51,7 +51,7 @@ GOTO inputAdapterName
 
 :checkAdapterName
 	echo.
-	netsh interface ip show address %netName% &&  GOTO confirmAdapter 2>nul GOTO inputAdapterName
+	netsh interface ip show address "%netName%" &&  GOTO confirmAdapter 2>nul GOTO inputAdapterName
 
 :confirmAdapter
 	echo. 
@@ -94,8 +94,7 @@ GOTO inputAdapterName
 
 :changeStatic
 	echo.
-	netsh interface ip show address %netName% > %filepath%
-	netsh interface ip set address %netName% static %ip% %nm% %gw% 
-	ECHO Success...Saved old configuration files on %filepath%
+	netsh interface ip show address "%netName%" > %filepath%
+	netsh interface ip set address "%netName%" static %ip% %nm% %gw% && ECHO Success...Saved old configuration files on %filepath% 2> echo Error while setting static IP
 
 PAUSE 

--- a/Set-IP/setStaticIP.bat
+++ b/Set-IP/setStaticIP.bat
@@ -95,6 +95,6 @@ GOTO inputAdapterName
 :changeStatic
 	echo.
 	netsh interface ip show address "%netName%" > %filepath%
-	netsh interface ip set address "%netName%" static %ip% %nm% %gw% && ECHO Success...Saved old configuration files on %filepath% 2> echo Error while setting static IP
+	netsh interface ip set address "%netName%" static %ip% %nm% %gw% && ECHO Success...Saved old configuration files on %filepath% 
 
 PAUSE 


### PR DESCRIPTION
Now users must type the name of their Ethernet Adapter.

Tested and approved on Windows 7 and 8.1
